### PR TITLE
Add kotlin support to bank account kata

### DIFF
--- a/bankAccount/20121206-shiv-paul/src/test/java/com/novoda/dojos/bankaccount/logging/StatementShould.java
+++ b/bankAccount/20121206-shiv-paul/src/test/java/com/novoda/dojos/bankaccount/logging/StatementShould.java
@@ -1,11 +1,7 @@
 package com.novoda.dojos.bankaccount.logging;
 
-import static junit.framework.Assert.assertTrue;
-import static org.mockito.Mockito.stub;
-
 import com.novoda.dojos.bankaccount.Account;
 import com.novoda.dojos.bankaccount.domain.Money;
-import com.novoda.dojos.bankaccount.logging.Statement;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -14,6 +10,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class StatementShould {
 
@@ -25,7 +24,7 @@ public class StatementShould {
 	public void setup(){
 		MockitoAnnotations.initMocks(this);
 		
-		stub(account.getBalance()).toReturn(balance);
+		when(account.getBalance()).thenReturn(balance);
 
 		statement = new Statement(account);
 	}

--- a/bankAccount/build.gradle
+++ b/bankAccount/build.gradle
@@ -1,3 +1,13 @@
+plugins {
+	id 'org.jetbrains.kotlin.jvm' version '1.2.71'
+}
 subprojects {
 	apply from: '../default/build.gradle'
 }
+repositories {
+	mavenCentral()
+}
+dependencies {
+	compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+}
+

--- a/bankAccount/default/build.gradle
+++ b/bankAccount/default/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'kotlin'
 
 repositories {
 	mavenCentral()
@@ -7,5 +8,27 @@ repositories {
 dependencies {
 	testCompile 'org.hamcrest:hamcrest-integration:1.2.1'
 	testCompile 'junit:junit-dep:4.10'
-	testCompile 'org.mockito:mockito-core:1.9.0'
+	testCompile 'org.mockito:mockito-core:2.22.0'
+	testCompile 'org.mockito:mockito-inline:2.22.0'
+	testCompile 'com.nhaarman:mockito-kotlin-kt1.1:1.6.0'
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+}
+buildscript {
+    ext.kotlin_version = '1.2.71'
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }

--- a/bankAccount/default/src/main/java/com/novoda/dojos/bankaccount/SomethingKotlin.kt
+++ b/bankAccount/default/src/main/java/com/novoda/dojos/bankaccount/SomethingKotlin.kt
@@ -1,0 +1,3 @@
+package com.novoda.dojos.bankaccount
+
+class SomethingKotlin

--- a/bankAccount/default/src/test/java/com/novoda/dojos/bankaccount/SomethingKotlinTest.kt
+++ b/bankAccount/default/src/test/java/com/novoda/dojos/bankaccount/SomethingKotlinTest.kt
@@ -1,0 +1,13 @@
+package com.novoda.dojos.bankaccount
+
+import com.nhaarman.mockito_kotlin.mock
+import org.junit.Test
+
+class SomethingKotlinTest {
+
+    @Test
+    fun `should be true`() {
+        val somethingKotlin = mock<SomethingKotlin>()
+        assert(somethingKotlin != null)
+    }
+}


### PR DESCRIPTION
**What is this about?**
This adds Kotlin support for the bank account kata.

**Considerations**
- Add kotlin and needed dependencies
- Bump mockito version to use inline feature to enable mocking of kotlin classes which are final per default